### PR TITLE
allow manual dispatching of mock-hosts.

### DIFF
--- a/.github/workflows/deploy-mock-hosts.yml
+++ b/.github/workflows/deploy-mock-hosts.yml
@@ -1,6 +1,21 @@
 name: Deploy Mock Hosts to Environment
 
 on:
+  workflow_dispatch:
+    inputs:
+      github-environment:
+        required: true
+        type: string
+      environment:
+        required: true
+        type: string
+      region:
+        required: false
+        type: string
+        default: 'us-east-1'
+    secrets:
+      ENV_SPECIFIC_SECRET:
+        required: true
   workflow_call:
     inputs:
       github-environment:


### PR DESCRIPTION
sometimes it's necessary to deploy the updated mock-host stacks before the other stacks due to export dependency issues.